### PR TITLE
7 implement prompt window

### DIFF
--- a/scripts/operators.py
+++ b/scripts/operators.py
@@ -11,6 +11,12 @@ class OBJECT_OT_import_plane_from_image(bpy.types.Operator, ImportHelper):
 
     directory: bpy.props.StringProperty(subtype="DIR_PATH")
 
+    filename_ext = ".png"
+    filter_glob: bpy.props.StringProperty(
+        default="*.png;*.jpg;*.jpeg",
+        options={'HIDDEN'}
+    )
+
     # 🔹 This adds the text input field
     hf_prompt: bpy.props.StringProperty(
         name="HF Prompt",


### PR DESCRIPTION
closes #7 

@ScarlettVFX 
Testing Required:

Verify that you can now enter a prompt for this, it should no longer be hardcoded

All unit test currently passing

```
josh@RollingThunder:~/git/ScarlettStudios/PlaneToPBR$ podman run --rm planetopbr-tests
============================= test session starts ==============================
platform linux -- Python 3.11.12, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
rootdir: /app
configfile: pytest.ini
testpaths: tests
collecting ... collected 8 items

tests/test_hf_client.py::TestHFClient::test_download_file PASSED         [ 12%]
tests/test_hf_client.py::TestHFClient::test_download_results PASSED      [ 25%]
tests/test_hf_client.py::TestHFClient::test_join_queue_success PASSED    [ 37%]
tests/test_hf_client.py::TestHFClient::test_poll_queue_success PASSED    [ 50%]
tests/test_hf_client.py::TestHFClient::test_resolve_fn_index_not_found PASSED [ 62%]
tests/test_hf_client.py::TestHFClient::test_resolve_fn_index_success PASSED [ 75%]
tests/test_utils.py::test_apply_pbr_textures_calls_expected_helpers PASSED [ 87%]
tests/test_utils.py::test_apply_pbr_textures_skips_missing_channels PASSED [100%]

============================== 8 passed in 0.09s ===============================
```