### PR TITLE
feat(properties): add scene properties for Platform API credentials

### DIFF
--- a/scripts/properties.py
+++ b/scripts/properties.py
@@ -9,10 +9,10 @@ def register():
     """
     Register custom Scene properties used by the PlaneToPBR add-on.
     """
-    # Text prompt sent to Hugging Face model
+    # Text prompt sent to AI model
     # Used to describe the desired material/surface
     bpy.types.Scene.planetopbr_prompt = StringProperty(
-        name="HF Prompt",
+        name="Prompt",
         description="Describe the material or surface",
         default="",
     )
@@ -26,6 +26,21 @@ def register():
         subtype='FILE_PATH'
     )
 
+    # Platform API email credential
+    bpy.types.Scene.planetopbr_email = StringProperty(
+        name="Email",
+        description="Platform API email address",
+        default="",
+    )
+
+    # Platform API password credential
+    bpy.types.Scene.planetopbr_password = StringProperty(
+        name="Password",
+        description="Platform API password",
+        default="",
+        subtype='PASSWORD'
+    )
+
 def unregister():
     """
     Cleanly remove Scene properties when the add-on is disabled.
@@ -33,3 +48,5 @@ def unregister():
     """
     del bpy.types.Scene.planetopbr_prompt
     del bpy.types.Scene.planetopbr_image_path
+    del bpy.types.Scene.planetopbr_email
+    del bpy.types.Scene.planetopbr_password


### PR DESCRIPTION
- Add planetopbr_email StringProperty for email address
- Add planetopbr_password StringProperty with PASSWORD subtype
- Register properties in register() function
- Clean up properties in unregister() function
- Rename planetopbr_prompt label from "HF Prompt" to "Prompt"
- Persist credentials with Blender scene file

Closes #55 